### PR TITLE
Revert "Add confluent/api to CLI's CODEOWNERS"

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,1 @@
-*	@confluentinc/cli @confluentinc/api
+*	@confluentinc/cli


### PR DESCRIPTION
Reverts confluentinc/homebrew-tap#49

The @confluentinc/api and @confluentinc/cli aliases have the same group of users